### PR TITLE
Update typing patch 3.7 to also comply with python 3.9

### DIFF
--- a/pyjsg/jsglib/typing_patch_37.py
+++ b/pyjsg/jsglib/typing_patch_37.py
@@ -1,13 +1,15 @@
-from typing import Dict, Any, Union, ForwardRef, Callable, Type
+import sys
 from collections.abc import Iterable
 
-
 # Typing_patch module for Python 3.7
+
+if sys.version_info >= (3, 7):
+    from typing import Dict, Any, Union, ForwardRef, Callable, Type, _eval_type
 
 
 def proc_forward(etype, namespace: Dict[str, Any]):
     """ Resolve etype to an actual type if it is a forward reference """
-    return etype._evaluate(namespace, namespace) if type(etype) is ForwardRef else etype
+    return _eval_type(etype, namespace, namespace) if type(etype) is ForwardRef else etype
 
 
 def is_union(etype) -> bool:

--- a/tests/test_basics/py/NodeConstraint.py
+++ b/tests/test_basics/py/NodeConstraint.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/NodeConstraint.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/NodeConstraint.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/OneOf.py
+++ b/tests/test_basics/py/OneOf.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/OneOf.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/OneOf.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/ShExJ.py
+++ b/tests/test_basics/py/ShExJ.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/ShExJ.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/ShExJ.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/StemRange.py
+++ b/tests/test_basics/py/StemRange.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/StemRange.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/StemRange.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/TypeAndIgnore.py
+++ b/tests/test_basics/py/TypeAndIgnore.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/TypeAndIgnore.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/TypeAndIgnore.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/complexfacet.py
+++ b/tests/test_basics/py/complexfacet.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/complexfacet.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/complexfacet.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/complexlexer.py
+++ b/tests/test_basics/py/complexlexer.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/complexlexer.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/complexlexer.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/emptyobject.py
+++ b/tests/test_basics/py/emptyobject.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/emptyobject.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/emptyobject.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/emptyspec.py
+++ b/tests/test_basics/py/emptyspec.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/emptyspec.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/emptyspec.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/example_1.py
+++ b/tests/test_basics/py/example_1.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/example_1.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/example_1.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/example_2.py
+++ b/tests/test_basics/py/example_2.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/example_2.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/example_2.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/example_3.py
+++ b/tests/test_basics/py/example_3.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/example_3.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/example_3.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/example_4.py
+++ b/tests/test_basics/py/example_4.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/example_4.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/example_4.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/example_5.py
+++ b/tests/test_basics/py/example_5.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/example_5.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/example_5.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/facet.py
+++ b/tests/test_basics/py/facet.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/facet.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/facet.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/labeledShapeExpr.py
+++ b/tests/test_basics/py/labeledShapeExpr.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/labeledShapeExpr.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/labeledShapeExpr.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/labeledShapeExpr1.py
+++ b/tests/test_basics/py/labeledShapeExpr1.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/labeledShapeExpr1.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/labeledShapeExpr1.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/labeledShapeExpr2.py
+++ b/tests/test_basics/py/labeledShapeExpr2.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/labeledShapeExpr2.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/labeledShapeExpr2.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/labeledShapeOr.py
+++ b/tests/test_basics/py/labeledShapeOr.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/labeledShapeOr.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/labeledShapeOr.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/lexer.py
+++ b/tests/test_basics/py/lexer.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/lexer.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/lexer.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/list_options.py
+++ b/tests/test_basics/py/list_options.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/list_options.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/list_options.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/listcardinalities.py
+++ b/tests/test_basics/py/listcardinalities.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/listcardinalities.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/listcardinalities.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/shapes.py
+++ b/tests/test_basics/py/shapes.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/shapes.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/shapes.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_basics/py/simplelexer.py
+++ b/tests/test_basics/py/simplelexer.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/simplelexer.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/simplelexer.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests/test_jsglib/py/ShExJ.py
+++ b/tests/test_jsglib/py/ShExJ.py
@@ -1,5 +1,5 @@
-# Auto generated from test_basics/jsg/ShExJ.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests/test_basics/jsg/ShExJ.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests_standalone/test_jsg_readme/py/ge1.py
+++ b/tests_standalone/test_jsg_readme/py/ge1.py
@@ -1,5 +1,5 @@
-# Auto generated from test_jsg_readme/jsg/ge1.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests_standalone/test_jsg_readme/jsg/ge1.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests_standalone/test_jsg_readme/py/ge2.py
+++ b/tests_standalone/test_jsg_readme/py/ge2.py
@@ -1,5 +1,5 @@
-# Auto generated from test_jsg_readme/jsg/ge2.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests_standalone/test_jsg_readme/jsg/ge2.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests_standalone/test_jsg_readme/py/pd1.py
+++ b/tests_standalone/test_jsg_readme/py/pd1.py
@@ -1,5 +1,5 @@
-# Auto generated from test_jsg_readme/jsg/pd1.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests_standalone/test_jsg_readme/jsg/pd1.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests_standalone/test_jsg_readme/py/pd2.py
+++ b/tests_standalone/test_jsg_readme/py/pd2.py
@@ -1,5 +1,5 @@
-# Auto generated from test_jsg_readme/jsg/pd2.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests_standalone/test_jsg_readme/jsg/pd2.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests_standalone/test_jsg_readme/py/pd3.py
+++ b/tests_standalone/test_jsg_readme/py/pd3.py
@@ -1,5 +1,5 @@
-# Auto generated from test_jsg_readme/jsg/pd3.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests_standalone/test_jsg_readme/jsg/pd3.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg

--- a/tests_standalone/test_jsg_readme/py/type_directive_1.py
+++ b/tests_standalone/test_jsg_readme/py/type_directive_1.py
@@ -1,5 +1,5 @@
-# Auto generated from test_jsg_readme/jsg/type_directive_1.jsg by PyJSG version 0.10.0
-# Generation date: 2020-05-12 12:31
+# Auto generated from tests_standalone/test_jsg_readme/jsg/type_directive_1.jsg by PyJSG version 0.10.0
+# Generation date: 2020-11-11 10:23
 #
 import typing
 import pyjsg.jsglib as jsg


### PR DESCRIPTION
There were some issues when running PyJSG with python 3.9, since in that version the evaluation of ForwardRefs was changed to avoid infinite recursion. This change now required an additional argument used as a recursive guard to evaluate the ForwardRef.

We changed the code to use the _eval_type function from typing, which has remained stable from python 3.7 and automatically adds the recursive guard in python 3.9.

However, we need to be careful when using the private function from typing, and if a more stable way of evaluating ForwardRefs is found, change to it to avoid problems with new python versions.