### PR TITLE
Experiment to determine if antlr4-python3-runtime 4.10 works

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,6 @@ requests = "*"
 yadict_compare = "*"
 
 [packages]
-antlr4-python3-runtime = "~=4.9"
+antlr4-python3-runtime = "~=4.10"
 jsonasobj = ">=1.2.1"
 


### PR DESCRIPTION
The main linkml branch is failing

we suspect 4.10 is the cause

see https://github.com/linkml/linkml/runs/6014859773?check_suite_focus=true#step:6:2637

```
======================================================================
ERROR: tests.test_biolink_model.test_biolink_model (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: tests.test_biolink_model.test_biolink_model
Traceback (most recent call last):
  File "/usr/lib/python3.8/unittest/loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "/usr/lib/python3.8/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/home/runner/work/linkml/linkml/tests/test_biolink_model/test_biolink_model.py", line 6, in <module>
    from pyshex import ShExEvaluator
  File "/home/runner/.local/share/virtualenvs/linkml-GXYf-q4E/lib/python3.8/site-packages/pyshex/__init__.py", line 1, in <module>
    from pyshex.prefixlib import PrefixLibrary, standard_prefixes, known_prefixes
  File "/home/runner/.local/share/virtualenvs/linkml-GXYf-q4E/lib/python3.8/site-packages/pyshex/prefixlib.py", line 4, in <module>
    from pyshexc.parser_impl.generate_shexj import load_shex_file
  File "/home/runner/.local/share/virtualenvs/linkml-GXYf-q4E/lib/python3.8/site-packages/pyshexc/parser_impl/generate_shexj.py", line 19, in <module>
    from pyshexc.parser.ShExDocLexer import ShExDocLexer
  File "/home/runner/.local/share/virtualenvs/linkml-GXYf-q4E/lib/python3.8/site-packages/pyshexc/parser/ShExDocLexer.py", line 449, in <module>
    class ShExDocLexer(Lexer):
  File "/home/runner/.local/share/virtualenvs/linkml-GXYf-q4E/lib/python3.8/site-packages/pyshexc/parser/ShExDocLexer.py", line 451, in ShExDocLexer
    atn = ATNDeserializer().deserialize(serializedATN())
  File "/home/runner/.local/share/virtualenvs/linkml-GXYf-q4E/lib/python3.8/site-packages/antlr4/atn/ATNDeserializer.py", line 28, in deserialize
    self.checkVersion()
  File "/home/runner/.local/share/virtualenvs/linkml-GXYf-q4E/lib/python3.8/site-packages/antlr4/atn/ATNDeserializer.py", line 50, in checkVersion
    raise Exception("Could not deserialize ATN with version " + str(version) + " (expected " + str(SERIALIZED_VERSION) + ").")
Exception: Could not deserialize ATN with version  (expected 4).
```